### PR TITLE
Add manifest for Android "Add to home"

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -11,6 +11,7 @@
 
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
     <link rel="stylesheet" href="{{rootURL}}assets/bodega.css">
+    <link rel="manifest" href="{{rootURL}}manifest.json">
 
     {{content-for "head-footer"}}
   </head>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,45 @@
+{
+  "name": "Bodega",
+  "icons": [
+    {
+      "src": "launcher-icon-0-75x.png",
+      "sizes": "36x36",
+      "type": "image/png",
+      "density": 0.75
+    },
+    {
+      "src": "launcher-icon-1x.png",
+      "sizes": "48x48",
+      "type": "image/png",
+      "density": 1.0
+    },
+    {
+      "src": "launcher-icon-1-5x.png",
+      "sizes": "72x72",
+      "type": "image/png",
+      "density": 1.5
+    },
+    {
+      "src": "launcher-icon-2x.png",
+      "sizes": "96x96",
+      "type": "image/png",
+      "density": 2.0
+    },
+    {
+      "src": "launcher-icon-3x.png",
+      "sizes": "144x144",
+      "type": "image/png",
+      "density": 3.0
+    },
+    {
+      "src": "launcher-icon-4x.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "density": 4.0
+    }
+  ],
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#FFFDE7",
+  "background_color": "#FFFDE7"
+}


### PR DESCRIPTION
This enables Android's add to home screen feature for web apps. Right now we don't have an icon for the home screen, but I'd like to leave the `icons` data in here so we know what resolutions to add later. For now it doesn't seem to hurt. 