### PR TITLE
link to share via SMS

### DIFF
--- a/app/components/show-item.js
+++ b/app/components/show-item.js
@@ -1,6 +1,16 @@
 import Ember from 'ember';
-const { Component } = Ember;
+const { Component, computed } = Ember;
+const { htmlSafe } = Ember.String;
+
+export function smsHref(id){
+  let url = `${window.location.origin}/item/${id}`;
+  return `sms:&body=Checkout this awesome sticker: ${url}`;
+}
 
 export default Component.extend({
-  isFocused: false
+  isFocused: false,
+  smsHref: computed('item.id', function() {
+    let id = this.get('item.id');
+    return htmlSafe(smsHref(id));
+  })
 });

--- a/app/templates/components/show-item.hbs
+++ b/app/templates/components/show-item.hbs
@@ -4,4 +4,10 @@
   <div class="show-item__image">
     <img src={{item.url}}>
   </div>
+
+  {{#if isFocused}}
+    <div class="show-item__sms">
+      <a href={{smsHref}}>Share by SMS</a>
+    </div>
+  {{/if}}
 </article>

--- a/tests/integration/components/show-item-test.js
+++ b/tests/integration/components/show-item-test.js
@@ -1,20 +1,32 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import testSelector from 'bodega/tests/helpers/ember-test-selectors';
+import { smsHref } from 'bodega/components/show-item';
 
 moduleForComponent('show-item', 'Integration | Component | show item', {
   integration: true
 });
 
 test('it renders', function(assert) {
-
-  // Set any properties with this.set('myProperty', 'value');
-  // Handle any actions with this.on('myAction', function(val) { ... });
-
   let item = {id: 1, name: 'my item', url: '/dummy-image', price: 1099};
   this.set('item', item);
   this.render(hbs`{{show-item item=item}}`);
 
   assert.ok(this.$(testSelector('item', item.id)).length, 'displays item');
   assert.ok(this.$(`img[src="${item.url}"]`).length, 'shows image');
+});
+
+test('show SMS link when focused', function(assert) {
+  let item = {id: 1, name: 'my item', url: '/dummy-image', price: 1099};
+  this.set('item', item);
+  this.set('isFocused', false);
+  this.render(hbs`{{show-item item=item isFocused=isFocused}}`);
+
+  assert.notOk(this.$('show-item.is-focused').length, 'no is-focused class');
+
+  this.set('isFocused', true);
+
+  assert.ok(this.$('.show-item.is-focused').length, 'is-focused class');
+  let href = smsHref(item.id);
+  assert.ok(this.$(`a[href="${href}"]`).length, 'user can see SMS link');
 });


### PR DESCRIPTION
Demonstrates that we can hook into phone API for sending messages and that we can link stickers via URL. Would be nice to have in a demo.

![](http://g.recordit.co/ozZsBku6zE.gif)

TODO:

 - [ ] Style the link @minusfive thoughts?
 - [ ] Hide when unsupported (ie. non-mobile)
