### PR TITLE
set live-reload-port to not clash with mac touchbar service

### DIFF
--- a/.ember-cli
+++ b/.ember-cli
@@ -6,5 +6,6 @@
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
   "disableAnalytics": false,
-  "ssl": true
+  "ssl": true,
+  "live-reload-port": 49153
 }


### PR DESCRIPTION
@bantic There is a known issue https://github.com/ember-cli/ember-cli/issues/6513 that some people with a touchbar Macbook Pro get an error `Livereload failed on http://localhost:49152.  It is either in use or you do not have permission.` when running ember server. Some process related to the touchbar listens on port 49152 which is the same port livereload tries to yes.

There is a fix https://github.com/ember-cli/ember-cli/pull/6545 to change the default port in ember-cli, but that hasn't been released yet, so in the meantime we should set it here.