### PR TITLE
Use navigator.onLine to check initial status

### DIFF
--- a/app/services/online.js
+++ b/app/services/online.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Service.extend({
-  isOnline: true,
+  isOnline: window.navigator ? window.navigator.onLine : true,
 
   init() {
     this._super(...arguments);


### PR DESCRIPTION
Fixes a bug where if you load the page while you are offline you start
in online mode by default but never get that 'offline' event, so the app
thinks you are offline.

for @iezer