### PR TITLE
shoebox to eliminate api call for items

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -3,5 +3,9 @@ import config from 'bodega/config/environment';
 
 export default DS.JSONAPIAdapter.extend({
   namespace: config.apiNamespace,
-  host: config.apiHost
+  host: config.apiHost,
+
+  shouldBackgroundReloadAll() {
+    return false;
+  }
 });

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.10.0",
+    "ember-data-fastboot": "0.0.2",
     "ember-elsewhere": "0.4.1",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",


### PR DESCRIPTION
 - use ember-data-fastboot to save ember data store into shoebox.

 - Implementation is pretty cool. See [here](https://github.com/cardstack/ember-data-fastboot/blob/master/app/instance-initializers/fastboot/ember-data-fastboot.js). the addon adds an initializer which pushes an object into the shoebox with a property getter that serializes the data store. The getter itself is run after the the page is rendered on the backend, to create the shoebox, so by that time the store is completely populated with everything the app needed while generating the page.

Also set `shouldBackgroundReloadAll` to false, otherwise the model hook will return right away but still do an API call.