### PR TITLE
Run tests with headless Firefox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,12 @@ node_js:
 
 sudo: required
 
+env:
+  - MOZ_HEADLESS=1
+
 addons:
   chrome: stable
+  firefox: latest
 
 cache:
   directories:

--- a/testem.js
+++ b/testem.js
@@ -3,7 +3,8 @@ module.exports = {
   test_page: 'tests/index.html?hidepassed',
   disable_watching: true,
   launch_in_ci: [
-    'Chrome'
+    'Chrome',
+    'Firefox'
   ],
   launch_in_dev: [
     'Chrome'
@@ -17,7 +18,12 @@ module.exports = {
         '--remote-debugging-port=0',
         '--window-size=1440,900'
       ]
+    },
+    Firefox: {
+      mode: 'ci',
+      args: [
+        '-headless',
+      ]
     }
   }
-
 };


### PR DESCRIPTION
This changes runs tests on Travis on both Chrome and Firefox. Local dev is Chrome only.

The test suite is small so there isn't much of an impact on build time.

Some more info in this [blog post](https://blog.201-created.com/testing-ember-applications-in-2018-4635ac241f00)